### PR TITLE
Enable Basic Destination Creation

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -31,6 +31,8 @@ func TestClientHello(t *testing.T) {
 func TestNewDestination(t *testing.T) {
 	setup(t)
 	t.Log(client.Base32())
-	client.NewDestination(SAMsigTypes[3])
+	if _, err := client.NewDestination(SAMsigTypes[3]); err != nil {
+		t.Error(err)
+	}
 	teardown(t)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -27,3 +27,10 @@ func TestClientHello(t *testing.T) {
 	t.Log(client.Base32())
 	teardown(t)
 }
+
+func TestNewDestination(t *testing.T) {
+	setup(t)
+	t.Log(client.Base32())
+	client.NewDestination(SAMsigTypes[3])
+	teardown(t)
+}

--- a/i2pkeys.go
+++ b/i2pkeys.go
@@ -1,0 +1,35 @@
+package goSam
+
+import (
+	"errors"
+
+	"github.com/eyedeekay/sam3/i2pkeys"
+)
+
+// NewDestination generates a new I2P destination, creating the underlying
+// public/private keys in the process. The public key can be used to send messages
+// to the destination, while the private key can be used to reply to messages
+func (c *Client) NewDestination(sigType ...string) (i2pkeys.I2PKeys, error) {
+	var (
+		sigtmp string
+		keys   i2pkeys.I2PKeys
+	)
+	if len(sigType) > 0 {
+		sigtmp = sigType[0]
+	}
+	r, err := c.sendCmd(
+		"DEST GENERATE %s\n",
+		sigtmp,
+	)
+	if err != nil {
+		return keys, err
+	}
+	var pub, priv string
+	if priv = r.Pairs["PRIV"]; priv == "" {
+		return keys, errors.New("failed to generate private destination key")
+	}
+	if pub = r.Pairs["PUB"]; pub == "" {
+		return keys, errors.New("failed to generate public destination key")
+	}
+	return i2pkeys.NewKeys(i2pkeys.I2PAddr(pub), priv), nil
+}


### PR DESCRIPTION
This allows basic destination creation, should it also allow more control over the destination that gets created? at the moment it only allows signature type selection. I basically copied this over from `eyedeekay/sam3`.