### PR TITLE
Fix Pass Lock By Value Vet Warning

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -30,7 +30,7 @@ func (c *Client) DialContext(ctx context.Context, network, addr string) (net.Con
 	}
 }
 
-func (c Client) dialCheck(addr string) (int32, bool) {
+func (c *Client) dialCheck(addr string) (int32, bool) {
 	if c.lastaddr == "invalid" {
 		fmt.Println("Preparing to dial new address.")
 		return c.NewID(), true


### PR DESCRIPTION
`go vet ./...` produces the following warning:
```
./dial.go:33:9: dialCheck passes lock by value: github.com/eyedeekay/goSam.Client contains sync.Mutex
```

This includes a fix for that, marking the dialCheck function as taking a pointer to the Client struct